### PR TITLE
Prevent Escaping on Numerics

### DIFF
--- a/lib/JsonBuilder.php
+++ b/lib/JsonBuilder.php
@@ -2,7 +2,7 @@
 //
 //  Module: JsonBuilder.php - G.J. Watson
 //    Desc: Json Object Builder
-// Version: 1.00
+// Version: 1.01
 //
 
 require_once("Common.php");
@@ -30,7 +30,7 @@ final class JsonBuilder {
         $output["function"]  = $this->function;
         $output["generated"] = $this->when;
         $output[$this->name] = $this->contents;
-        return json_encode($output);
+        return json_encode($output, JSON_NUMERIC_CHECK);
     }
 
 }

--- a/lib/Test/JsonBuilderTest.php
+++ b/lib/Test/JsonBuilderTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-set_include_path("../../PHP-QuoteServiceOO");
+set_include_path("../../PHP-QuoteServiceOO/lib/db");
 
 require_once("Author.php");
 require_once("JsonBuilder.php");


### PR DESCRIPTION
Added directive to json_encode to ensure numerics are not escaped in JSON strings